### PR TITLE
Fix migration for laravel 5.8

### DIFF
--- a/migrations/2020_12_24_000000_create_user_tokens_table.php
+++ b/migrations/2020_12_24_000000_create_user_tokens_table.php
@@ -14,7 +14,7 @@ class CreateUserTokensTable extends Migration
     public function up()
     {
         Schema::create('user_tokens', function (Blueprint $table) {
-            $table->id();
+            $table->increments('id');
             $table->string('auth_identifier', 255);
             $table->string('token');
             $table->boolean('remember')->default(0);


### PR DESCRIPTION
Fix bugs
```
 BadMethodCallException  : Method Illuminate\Database\Schema\Blueprint::id does not exist.
```
when run migration on laravel 5.8